### PR TITLE
replace delimiter in "addr type - src addr" by ";"

### DIFF
--- a/app/scanner.c
+++ b/app/scanner.c
@@ -54,7 +54,7 @@ static void _on_disc(uint8_t type,
     pos += fmt_u32_dec(&tmp[pos], (uint32_t)type);
     tmp[pos++] = ';';
     pos += fmt_u32_dec(&tmp[pos], (uint32_t)addr->type);
-    tmp[pos++] = '-';
+    tmp[pos++] = ';';
     bluetil_addr_sprint(&tmp[pos], addr->val);
     pos += BLUETIL_ADDR_STRLEN - 1;
     tmp[pos++] = ';';


### PR DESCRIPTION
using the same delimiter for all fields eases post-processing. using different delimiters requires multiple splits.